### PR TITLE
chore: use the agent endpoint declarations in Tapir2StaticOAS

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
@@ -2,24 +2,18 @@ package io.iohk.atala.agent.server
 
 import io.iohk.atala.agent.notification.WebhookPublisher
 import io.iohk.atala.agent.server.config.AppConfig
-import io.iohk.atala.agent.server.http.ZHttp4sBlazeServer
-import io.iohk.atala.agent.server.http.ZHttpEndpoints
-import io.iohk.atala.agent.server.jobs.BackgroundJobs
-import io.iohk.atala.agent.server.jobs.ConnectBackgroundJobs
+import io.iohk.atala.agent.server.http.{ZHttp4sBlazeServer, ZHttpEndpoints}
+import io.iohk.atala.agent.server.jobs.{BackgroundJobs, ConnectBackgroundJobs}
 import io.iohk.atala.agent.walletapi.service.ManagedDIDService
-import io.iohk.atala.castor.controller.DIDRegistrarServerEndpoints
-import io.iohk.atala.castor.controller.DIDServerEndpoints
+import io.iohk.atala.castor.controller.{DIDRegistrarServerEndpoints, DIDServerEndpoints}
 import io.iohk.atala.castor.core.service.DIDService
 import io.iohk.atala.connect.controller.ConnectionServerEndpoints
 import io.iohk.atala.connect.core.service.ConnectionService
 import io.iohk.atala.issue.controller.IssueServerEndpoints
-import io.iohk.atala.mercury.DidOps
-import io.iohk.atala.mercury.HttpClient
-import io.iohk.atala.pollux.core.service.CredentialService
-import io.iohk.atala.pollux.core.service.PresentationService
+import io.iohk.atala.mercury.{DidOps, HttpClient}
+import io.iohk.atala.pollux.core.service.{CredentialService, PresentationService}
 import io.iohk.atala.pollux.credentialdefinition.CredentialDefinitionRegistryServerEndpoints
-import io.iohk.atala.pollux.credentialschema.SchemaRegistryServerEndpoints
-import io.iohk.atala.pollux.credentialschema.VerificationPolicyServerEndpoints
+import io.iohk.atala.pollux.credentialschema.{SchemaRegistryServerEndpoints, VerificationPolicyServerEndpoints}
 import io.iohk.atala.pollux.vc.jwt.DidResolver as JwtDidResolver
 import io.iohk.atala.presentproof.controller.PresentProofServerEndpoints
 import io.iohk.atala.resolvers.DIDResolver
@@ -82,30 +76,32 @@ object PrismAgentApp {
 }
 
 object AgentHttpServer {
+  val agentRESTServiceEndpoints = for {
+    allCredentialDefinitionRegistryEndpoints <- CredentialDefinitionRegistryServerEndpoints.all
+    allSchemaRegistryEndpoints <- SchemaRegistryServerEndpoints.all
+    allVerificationPolicyEndpoints <- VerificationPolicyServerEndpoints.all
+    allConnectionEndpoints <- ConnectionServerEndpoints.all
+    allIssueEndpoints <- IssueServerEndpoints.all
+    allDIDEndpoints <- DIDServerEndpoints.all
+    allDIDRegistrarEndpoints <- DIDRegistrarServerEndpoints.all
+    allPresentProofEndpoints <- PresentProofServerEndpoints.all
+    allSystemEndpoints <- SystemServerEndpoints.all
+  } yield allCredentialDefinitionRegistryEndpoints ++
+    allSchemaRegistryEndpoints ++
+    allVerificationPolicyEndpoints ++
+    allConnectionEndpoints ++
+    allDIDEndpoints ++
+    allDIDRegistrarEndpoints ++
+    allIssueEndpoints ++
+    allPresentProofEndpoints ++
+    allSystemEndpoints
+
   def run =
     for {
-      allCredentialDefinitionRegistryEndpoints <- CredentialDefinitionRegistryServerEndpoints.all
-      allSchemaRegistryEndpoints <- SchemaRegistryServerEndpoints.all
-      allVerificationPolicyEndpoints <- VerificationPolicyServerEndpoints.all
-      allConnectionEndpoints <- ConnectionServerEndpoints.all
-      allIssueEndpoints <- IssueServerEndpoints.all
-      allDIDEndpoints <- DIDServerEndpoints.all
-      allDIDRegistrarEndpoints <- DIDRegistrarServerEndpoints.all
-      allPresentProofEndpoints <- PresentProofServerEndpoints.all
-      allSystemEndpoints <- SystemServerEndpoints.all
-      allEndpoints = ZHttpEndpoints.withDocumentations[Task](
-        allCredentialDefinitionRegistryEndpoints ++
-          allSchemaRegistryEndpoints ++
-          allVerificationPolicyEndpoints ++
-          allConnectionEndpoints ++
-          allDIDEndpoints ++
-          allDIDRegistrarEndpoints ++
-          allIssueEndpoints ++
-          allPresentProofEndpoints ++
-          allSystemEndpoints
-      )
+      allEndpoints <- agentRESTServiceEndpoints
+      allEndpointsWithDocumentation = ZHttpEndpoints.withDocumentations[Task](allEndpoints)
       server <- ZHttp4sBlazeServer.make
       appConfig <- ZIO.service[AppConfig]
-      _ <- server.start(allEndpoints, port = appConfig.agent.httpEndpoint.http.port).debug
+      _ <- server.start(allEndpointsWithDocumentation, port = appConfig.agent.httpEndpoint.http.port).debug
     } yield ()
 }

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/api/util/Tapir2StaticOAS.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/api/util/Tapir2StaticOAS.scala
@@ -1,17 +1,13 @@
 package io.iohk.atala.api.util
 
-import io.iohk.atala.castor.controller.{
-  DIDController,
-  DIDRegistrarController,
-  DIDRegistrarServerEndpoints,
-  DIDServerEndpoints
-}
-import io.iohk.atala.connect.controller.{ConnectionController, ConnectionServerEndpoints}
-import io.iohk.atala.issue.controller.{IssueController, IssueServerEndpoints}
+import io.iohk.atala.agent.server.AgentHttpServer
+import io.iohk.atala.castor.controller.{DIDController, DIDRegistrarController}
+import io.iohk.atala.connect.controller.ConnectionController
+import io.iohk.atala.issue.controller.IssueController
+import io.iohk.atala.pollux.credentialdefinition.controller.CredentialDefinitionController
 import io.iohk.atala.pollux.credentialschema.controller.{CredentialSchemaController, VerificationPolicyController}
-import io.iohk.atala.pollux.credentialschema.{SchemaRegistryServerEndpoints, VerificationPolicyServerEndpoints}
-import io.iohk.atala.presentproof.controller.{PresentProofController, PresentProofServerEndpoints}
-import io.iohk.atala.system.controller.{SystemController, SystemServerEndpoints}
+import io.iohk.atala.presentproof.controller.PresentProofController
+import io.iohk.atala.system.controller.SystemController
 import org.scalatestplus.mockito.MockitoSugar.*
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import zio.{Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
@@ -25,22 +21,7 @@ object Tapir2StaticOAS extends ZIOAppDefault {
   @main override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
     val effect = for {
       args <- getArgs
-      allSchemaRegistryEndpoints <- SchemaRegistryServerEndpoints.all
-      allVerificationPolicyEndpoints <- VerificationPolicyServerEndpoints.all
-      allConnectionEndpoints <- ConnectionServerEndpoints.all
-      allIssueEndpoints <- IssueServerEndpoints.all
-      allDIDEndpoints <- DIDServerEndpoints.all
-      allDIDRegistrarEndpoints <- DIDRegistrarServerEndpoints.all
-      allPresentProofEndpoints <- PresentProofServerEndpoints.all
-      allSystemEndpoints <- SystemServerEndpoints.all
-      allEndpoints = allSchemaRegistryEndpoints ++
-        allVerificationPolicyEndpoints ++
-        allConnectionEndpoints ++
-        allDIDEndpoints ++
-        allDIDRegistrarEndpoints ++
-        allIssueEndpoints ++
-        allPresentProofEndpoints ++
-        allSystemEndpoints
+      allEndpoints <- AgentHttpServer.agentRESTServiceEndpoints
     } yield {
       import sttp.apispec.openapi.circe.yaml.*
       val yaml = OpenAPIDocsInterpreter().toOpenAPI(allEndpoints.map(_.endpoint), "Prism Agent", args(1)).toYaml
@@ -49,6 +30,7 @@ object Tapir2StaticOAS extends ZIOAppDefault {
     }
     effect.provideSomeLayer(
       ZLayer.succeed(mock[ConnectionController]) ++
+        ZLayer.succeed(mock[CredentialDefinitionController]) ++
         ZLayer.succeed(mock[CredentialSchemaController]) ++
         ZLayer.succeed(mock[VerificationPolicyController]) ++
         ZLayer.succeed(mock[DIDRegistrarController]) ++


### PR DESCRIPTION
# Overview
This ensures the list of endpoints used as input to the Tapir2StaticOAS tool is the same as the one used by the agent at runtime.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
