### PR TITLE
fix(prism-agent): make resolve did representation content type work

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/api/http/codec/DIDCodec.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/api/http/codec/DIDCodec.scala
@@ -17,7 +17,12 @@ object DIDCodec {
   }
 
   def emptyDidJsonLD: Codec[String, DIDResolutionResult, DIDJsonLD] =
-    didJsonLD.schema(s => Schema.schemaForString.description("Empty representation").as)
+    didJsonLD.schema(_ =>
+      Schema.schemaForByteArray
+        .description("Empty representation")
+        .encodedExample(Array.emptyByteArray)
+        .as
+    )
 
   def didJsonLD: Codec[String, DIDResolutionResult, DIDJsonLD] = {
     val errorMsg = "Decoding application/did+ld+json resource is not supported"

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/castor/controller/DIDEndpoints.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/castor/controller/DIDEndpoints.scala
@@ -26,51 +26,51 @@ object DIDEndpoints {
   val resolutionEndpointOutput = oneOf[DIDResolutionResult](
     oneOfVariantValueMatcher(
       StatusCode.Ok,
-      oneOfBody[DIDResolutionResult](
-        stringBodyUtf8AnyFormat(didResolutionJsonLD),
-        stringBodyUtf8AnyFormat(didJsonLD)
+      oneOf[DIDResolutionResult](
+        oneOfVariant(stringBodyUtf8AnyFormat(didResolutionJsonLD)),
+        oneOfVariant(stringBodyUtf8AnyFormat(didJsonLD))
       )
     )(matchStatus(StatusCode.Ok)),
     oneOfVariantValueMatcher(
       StatusCode.BadRequest,
-      oneOfBody[DIDResolutionResult](
-        stringBodyUtf8AnyFormat(didResolutionJsonLD),
-        stringBodyUtf8AnyFormat(emptyDidJsonLD)
+      oneOf[DIDResolutionResult](
+        oneOfVariant(stringBodyUtf8AnyFormat(didResolutionJsonLD)),
+        oneOfVariant(stringBodyUtf8AnyFormat(emptyDidJsonLD))
       )
     )(matchStatus(StatusCode.BadRequest)),
     oneOfVariantValueMatcher(
       StatusCode.NotFound,
-      oneOfBody[DIDResolutionResult](
-        stringBodyUtf8AnyFormat(didResolutionJsonLD),
-        stringBodyUtf8AnyFormat(emptyDidJsonLD)
+      oneOf[DIDResolutionResult](
+        oneOfVariant(stringBodyUtf8AnyFormat(didResolutionJsonLD)),
+        oneOfVariant(stringBodyUtf8AnyFormat(emptyDidJsonLD))
       )
     )(matchStatus(StatusCode.NotFound)),
     oneOfVariantValueMatcher(
       StatusCode.NotAcceptable,
-      oneOfBody[DIDResolutionResult](
-        stringBodyUtf8AnyFormat(didResolutionJsonLD),
-        stringBodyUtf8AnyFormat(emptyDidJsonLD)
+      oneOf[DIDResolutionResult](
+        oneOfVariant(stringBodyUtf8AnyFormat(didResolutionJsonLD)),
+        oneOfVariant(stringBodyUtf8AnyFormat(emptyDidJsonLD))
       )
     )(matchStatus(StatusCode.NotAcceptable)),
     oneOfVariantValueMatcher(
       StatusCode.Gone,
-      oneOfBody[DIDResolutionResult](
-        stringBodyUtf8AnyFormat(didResolutionJsonLD),
-        stringBodyUtf8AnyFormat(emptyDidJsonLD)
+      oneOf[DIDResolutionResult](
+        oneOfVariant(stringBodyUtf8AnyFormat(didResolutionJsonLD)),
+        oneOfVariant(stringBodyUtf8AnyFormat(emptyDidJsonLD))
       )
     )(matchStatus(StatusCode.Gone)),
     oneOfVariantValueMatcher(
       StatusCode.NotImplemented,
-      oneOfBody[DIDResolutionResult](
-        stringBodyUtf8AnyFormat(didResolutionJsonLD),
-        stringBodyUtf8AnyFormat(emptyDidJsonLD)
+      oneOf[DIDResolutionResult](
+        oneOfVariant(stringBodyUtf8AnyFormat(didResolutionJsonLD)),
+        oneOfVariant(stringBodyUtf8AnyFormat(emptyDidJsonLD))
       )
     )(matchStatus(StatusCode.NotImplemented)),
     oneOfVariantValueMatcher(
       StatusCode.InternalServerError,
-      oneOfBody[DIDResolutionResult](
-        stringBodyUtf8AnyFormat(didResolutionJsonLD),
-        stringBodyUtf8AnyFormat(emptyDidJsonLD)
+      oneOf[DIDResolutionResult](
+        oneOfVariant(stringBodyUtf8AnyFormat(didResolutionJsonLD)),
+        oneOfVariant(stringBodyUtf8AnyFormat(emptyDidJsonLD))
       )
     )(_ => true),
   )


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes ATL-5198

Previous PR #616 make the OAS document more accurate, but it broke the content negotiation of the resolution. This PR make the content negotiation work again.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [x] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
