### PR TITLE
fix: change private sdk 1.4 to public maven

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val V = new {
   val logback = "1.4.8"
   val slf4j = "2.0.7"
 
-  val prismSdk = "v1.4.1" // scala-steward:off
+  val prismSdk = "1.4.1" // scala-steward:off
   val scalaUri = "4.0.3"
 
   val jwtCirceVersion = "9.1.2"
@@ -613,8 +613,6 @@ val irisClient = project
 
 val castorCommonSettings = Seq(
   testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
-  githubTokenSource := TokenSource.Environment("GITHUB_TOKEN"),
-  resolvers += Resolver.githubPackages("input-output-hk"),
   // Needed for Kotlin coroutines that support new memory management mode
   resolvers += "JetBrains Space Maven Repository" at "https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven"
 )
@@ -635,8 +633,6 @@ lazy val castorCore = project
 
 val polluxCommonSettings = Seq(
   testFrameworks ++= Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
-  githubTokenSource := TokenSource.Environment("GITHUB_TOKEN"),
-  resolvers += Resolver.githubPackages("input-output-hk"),
   // Needed for Kotlin coroutines that support new memory management mode
   resolvers += "JetBrains Space Maven Repository" at "https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven"
 )


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Changes private SDK 1.4 dependency to public maven central

One version of PRISM SDK 1.4 is now publicly available on Maven Central:
https://central.sonatype.com/artifact/io.iohk.atala

This removes the last private dependency for the repository.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [x] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
