### PR TITLE
fix(prism-agent): update invitation expiration on connection request

### DIFF
--- a/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/model/error/ConnectionServiceError.scala
+++ b/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/model/error/ConnectionServiceError.scala
@@ -12,5 +12,6 @@ object ConnectionServiceError {
   final case class UnexpectedError(msg: String) extends ConnectionServiceError
   final case class InvalidFlowStateError(msg: String) extends ConnectionServiceError
   final case class InvitationAlreadyReceived(msg: String) extends ConnectionServiceError
+  final case class InvitationExpired(msg: String) extends ConnectionServiceError
 
 }

--- a/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/ConnectionService.scala
+++ b/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/ConnectionService.scala
@@ -24,7 +24,11 @@ trait ConnectionService {
 
   def markConnectionRequestSent(recordId: UUID): IO[ConnectionServiceError, ConnectionRecord]
 
-  def receiveConnectionRequest(request: ConnectionRequest): IO[ConnectionServiceError, ConnectionRecord]
+  // def receiveConnectionRequest(request: ConnectionRequest): IO[ConnectionServiceError, ConnectionRecord]
+  def receiveConnectionRequest(
+      request: ConnectionRequest,
+      expirationTime: Option[Duration]
+  ): IO[ConnectionServiceError, ConnectionRecord]
 
   def acceptConnectionRequest(recordId: UUID): IO[ConnectionServiceError, ConnectionRecord]
 

--- a/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/ConnectionServiceImpl.scala
+++ b/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/ConnectionServiceImpl.scala
@@ -16,7 +16,7 @@ import zio.*
 import java.rmi.UnexpectedException
 import java.time.Instant
 import java.util.UUID
-
+import java.time.Duration
 private class ConnectionServiceImpl(
     connectionRepository: ConnectionRepository[Task],
     maxRetries: Int = 5, // TODO move to config
@@ -176,13 +176,25 @@ private class ConnectionServiceImpl(
     }
 
   override def receiveConnectionRequest(
-      request: ConnectionRequest
+      request: ConnectionRequest,
+      expirationTime: Option[Duration] = None
   ): IO[ConnectionServiceError, ConnectionRecord] =
     for {
       record <- getRecordFromThreadIdAndState(
         Some(request.thid.orElse(request.pthid).getOrElse(request.id)),
         ProtocolState.InvitationGenerated
       )
+      _ <- expirationTime.fold {
+        ZIO.unit
+      } { expiryDuration =>
+        val actualDuration = Duration.between(record.createdAt, Instant.now())
+        if (actualDuration > expiryDuration) {
+          for {
+            _ <- markConnectionInvitationExpired(record.id)
+            result <- ZIO.fail(InvitationExpired(record.id.toString))
+          } yield result
+        } else ZIO.unit
+      }
       _ <- connectionRepository
         .updateWithConnectionRequest(record.id, request, ProtocolState.ConnectionRequestReceived, maxRetries)
         .flatMap {

--- a/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/ConnectionServiceNotifier.scala
+++ b/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/ConnectionServiceNotifier.scala
@@ -7,6 +7,7 @@ import io.iohk.atala.mercury.model.DidId
 import io.iohk.atala.mercury.protocol.connection.{ConnectionRequest, ConnectionResponse}
 import zio.{IO, URLayer, ZIO, ZLayer}
 
+import java.time.Duration
 import java.util.UUID
 
 class ConnectionServiceNotifier(
@@ -34,8 +35,11 @@ class ConnectionServiceNotifier(
   override def markConnectionRequestSent(recordId: UUID): IO[ConnectionServiceError, ConnectionRecord] =
     notifyOnSuccess(svc.markConnectionRequestSent(recordId))
 
-  override def receiveConnectionRequest(request: ConnectionRequest): IO[ConnectionServiceError, ConnectionRecord] =
-    notifyOnSuccess(svc.receiveConnectionRequest(request))
+  override def receiveConnectionRequest(
+      request: ConnectionRequest,
+      expirationTime: Option[Duration]
+  ): IO[ConnectionServiceError, ConnectionRecord] =
+    notifyOnSuccess(svc.receiveConnectionRequest(request, expirationTime))
 
   override def acceptConnectionRequest(recordId: UUID): IO[ConnectionServiceError, ConnectionRecord] =
     notifyOnSuccess(svc.acceptConnectionRequest(recordId))

--- a/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/MockConnectionService.scala
+++ b/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/MockConnectionService.scala
@@ -7,6 +7,7 @@ import io.iohk.atala.mercury.protocol.connection.{ConnectionRequest, ConnectionR
 import zio.mock.{Mock, Proxy}
 import zio.{IO, URLayer, ZIO, ZLayer, mock}
 
+import java.time.Duration
 import java.util.UUID
 
 object MockConnectionService extends Mock[ConnectionService] {
@@ -44,7 +45,10 @@ object MockConnectionService extends Mock[ConnectionService] {
       override def markConnectionRequestSent(recordId: UUID): IO[ConnectionServiceError, ConnectionRecord] =
         proxy(MarkConnectionRequestSent, recordId)
 
-      override def receiveConnectionRequest(request: ConnectionRequest): IO[ConnectionServiceError, ConnectionRecord] =
+      override def receiveConnectionRequest(
+          request: ConnectionRequest,
+          expirationTime: Option[Duration]
+      ): IO[ConnectionServiceError, ConnectionRecord] =
         proxy(ReceiveConnectionRequest, request)
 
       override def acceptConnectionRequest(recordId: UUID): IO[ConnectionServiceError, ConnectionRecord] =

--- a/connect/lib/core/src/test/scala/io/iohk/atala/connect/core/service/ConnectionServiceImplSpec.scala
+++ b/connect/lib/core/src/test/scala/io/iohk/atala/connect/core/service/ConnectionServiceImplSpec.scala
@@ -221,7 +221,10 @@ object ConnectionServiceImplSpec extends ZIOSpecDefault {
             )
             connectionRequest = maybeAcceptedInvitationRecord.connectionRequest.get
             expiryTime = Duration.fromSeconds(300)
-            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(connectionRequest, Some(expiryTime))
+            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(
+              connectionRequest,
+              Some(expiryTime)
+            )
             maybeAcceptedRequestConnectionRecord <- inviterSvc.acceptConnectionRequest(inviterRecord.id)
             allInviterRecords <- inviterSvc.getConnectionRecords()
           } yield {
@@ -253,7 +256,10 @@ object ConnectionServiceImplSpec extends ZIOSpecDefault {
             _ <- inviteeSvc.markConnectionRequestSent(inviteeRecord.id)
             expiryTime = Duration.fromSeconds(300)
 
-            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(connectionRequest,Some(expiryTime))
+            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(
+              connectionRequest,
+              Some(expiryTime)
+            )
             maybeAcceptedRequestConnectionRecord <- inviterSvc.acceptConnectionRequest(inviterRecord.id)
             connectionResponseMessage <- ZIO.fromEither(
               maybeAcceptedRequestConnectionRecord.connectionResponse.get.makeMessage.asJson.as[Message]

--- a/connect/lib/core/src/test/scala/io/iohk/atala/connect/core/service/ConnectionServiceImplSpec.scala
+++ b/connect/lib/core/src/test/scala/io/iohk/atala/connect/core/service/ConnectionServiceImplSpec.scala
@@ -167,7 +167,7 @@ object ConnectionServiceImplSpec extends ZIOSpecDefault {
             )
             // FIXME: Should the service return an Option while we have dedicated "not found" error for that case !?
             connectionRequest = maybeAcceptedInvitationRecord.connectionRequest.get
-            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(connectionRequest)
+            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(connectionRequest, None)
             allInviterRecords <- inviterSvc.getConnectionRecords()
           } yield {
             val updatedRecord = maybeReceivedRequestConnectionRecord
@@ -194,8 +194,8 @@ object ConnectionServiceImplSpec extends ZIOSpecDefault {
             )
             connectionRequest = maybeAcceptedInvitationRecord.connectionRequest.get
             connectionRecordUpdated <- inviterSvc.markConnectionInvitationExpired(inviterRecord.id)
-
-            exit <- inviterSvc.receiveConnectionRequest(connectionRequest).exit
+            expiryTime = Duration.fromSeconds(300)
+            exit <- inviterSvc.receiveConnectionRequest(connectionRequest, Some(expiryTime)).exit
 
           } yield {
             assertTrue(exit match
@@ -220,7 +220,8 @@ object ConnectionServiceImplSpec extends ZIOSpecDefault {
               DidId("did:peer:INVITEE")
             )
             connectionRequest = maybeAcceptedInvitationRecord.connectionRequest.get
-            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(connectionRequest)
+            expiryTime = Duration.fromSeconds(300)
+            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(connectionRequest, Some(expiryTime))
             maybeAcceptedRequestConnectionRecord <- inviterSvc.acceptConnectionRequest(inviterRecord.id)
             allInviterRecords <- inviterSvc.getConnectionRecords()
           } yield {
@@ -250,7 +251,9 @@ object ConnectionServiceImplSpec extends ZIOSpecDefault {
             )
             connectionRequest = maybeAcceptedInvitationRecord.connectionRequest.get
             _ <- inviteeSvc.markConnectionRequestSent(inviteeRecord.id)
-            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(connectionRequest)
+            expiryTime = Duration.fromSeconds(300)
+
+            maybeReceivedRequestConnectionRecord <- inviterSvc.receiveConnectionRequest(connectionRequest,Some(expiryTime))
             maybeAcceptedRequestConnectionRecord <- inviterSvc.acceptConnectionRequest(inviterRecord.id)
             connectionResponseMessage <- ZIO.fromEither(
               maybeAcceptedRequestConnectionRecord.connectionResponse.get.makeMessage.asJson.as[Message]

--- a/connect/lib/core/src/test/scala/io/iohk/atala/connect/core/service/ConnectionServiceNotifierSpec.scala
+++ b/connect/lib/core/src/test/scala/io/iohk/atala/connect/core/service/ConnectionServiceNotifierSpec.scala
@@ -78,7 +78,8 @@ object ConnectionServiceNotifierSpec extends ZIOSpecDefault {
               thid = Some(connectionRecord.thid),
               pthid = None,
               body = ConnectionRequest.Body()
-            )
+            ),
+            None
           )
           _ <- cs.acceptConnectionRequest(connectionRecord.id)
           _ <- cs.markConnectionResponseSent(connectionRecord.id)

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/connect/controller/ConnectionController.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/connect/controller/ConnectionController.scala
@@ -49,4 +49,6 @@ object ConnectionController {
         ErrorResponse.badRequest(title = "InvalidFlowState", detail = Some(msg))
       case ConnectionServiceError.InvitationAlreadyReceived(msg) =>
         ErrorResponse.badRequest(title = "InvitationAlreadyReceived", detail = Some(msg))
+      case ConnectionServiceError.InvitationExpired(msg) =>
+        ErrorResponse.badRequest(title = "InvitationExpired", detail = Some(msg))
 }


### PR DESCRIPTION


# Overview
The Invitee will check the invitation expiry against the configured expiration time, If the message is received within the expiration time the connection request will be accepted, If the connection request message is received after the expiration time it will update the state of the Invitation to Invitation Expired. 
On the Invitee side since it is did comm message the Invitee will try the same message until configured max retries.
Since we have not implemented ReportProblem in Connect Protocol we will need accept this behaviour for now

Fixes ATL-5436

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
