### PR TITLE
fix(prism-agent): refine default wallet and webhook configuration behavior

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -788,7 +788,7 @@ lazy val prismAgentServer = project
   )
   .enablePlugins(JavaAppPackaging, DockerPlugin)
   .enablePlugins(BuildInfoPlugin)
-  .dependsOn(prismAgentWalletAPI)
+  .dependsOn(prismAgentWalletAPI % "compile->compile;test->test")
   .dependsOn(
     agent,
     polluxCore,

--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -169,6 +169,25 @@ agent {
         }
     }
     webhookPublisher {
+        url = ${?GLOBAL_WEBHOOK_URL}
+        apiKey = ${?GLOBAL_WEBHOOK_API_KEY}
         parallelism = ${?WEBHOOK_PARALLELISM}
+    }
+
+    defaultWallet {
+        // A configuration for initializing default wallet.
+        //
+        // Once a default wallet is initialized, the agent will use persisted configurations
+        // from its storage and may ignore these parameters.
+        enabled = true
+        enabled = ${?DEFAULT_WALLET_ENABLED}
+
+        seed = ${?DEFAULT_WALLET_SEED}
+
+        webhookUrl = ${?DEFAULT_WALLET_WEBHOOK_URL}
+        webhookApiKey = ${?DEFAULT_WALLET_WEBHOOK_API_KEY}
+
+        authApiKey = "default"
+        authApiKey = ${?DEFAULT_WALLET_AUTH_API_KEY}
     }
 }

--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -177,13 +177,18 @@ agent {
     defaultWallet {
         // A configuration for initializing default wallet.
         //
-        // Once a default wallet is initialized, the agent will use persisted configurations
+        // Once the default wallet is initialized, the agent will use persisted configurations
         // from its storage and may ignore these parameters.
         enabled = true
         enabled = ${?DEFAULT_WALLET_ENABLED}
 
+        // Wallet seed to be used for the default wallet. If not provided, it will be generated.
         seed = ${?DEFAULT_WALLET_SEED}
 
+        // Webhook url of the default wallet.
+        // If provided, webhook notification will be created when wallet is initialized.
+        // If not provided, webhook will not be created.
+        // If provided after the default wallet has been initialized, it will not have any effect.
         webhookUrl = ${?DEFAULT_WALLET_WEBHOOK_URL}
         webhookApiKey = ${?DEFAULT_WALLET_WEBHOOK_API_KEY}
 

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/notification/WebhookPublisher.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/notification/WebhookPublisher.scala
@@ -26,6 +26,10 @@ class WebhookPublisher(
 
   private val baseHeaders = Headers.contentType(HeaderValues.applicationJson)
 
+  private val globalWebhookBaseHeaders = config.apiKey
+    .map(key => Headers.bearerAuthorizationHeader(key))
+    .getOrElse(Headers.empty)
+
   private val parallelism = config.parallelism.getOrElse(1).max(1).min(10)
 
   val run: ZIO[Client, WebhookPublisherError, Unit] = {
@@ -54,7 +58,7 @@ class WebhookPublisher(
       _ <- ZIO.log(s"Polling $parallelism event(s)")
       events <- consumer.poll(parallelism).mapError(e => UnexpectedError(e.toString))
       _ <- ZIO.log(s"Got ${events.size} event(s)")
-      allWebhookUrls <- ZIO
+      allWebhooks <- ZIO
         .foreach(events.map(_.walletId).toSet.toList) { walletId =>
           walletService.listWalletNotifications
             .map(walletId -> _)
@@ -62,27 +66,41 @@ class WebhookPublisher(
         }
         .map(_.toMap)
       _ <- ZIO.foreachPar(events) { e =>
-        val webhookUrls = allWebhookUrls.getOrElse(e.walletId, Nil)
-        ZIO.foreach(webhookUrls) { webhookUrl =>
-          notifyWebhook(e, webhookUrl)
-            .retry(Schedule.spaced(5.second) && Schedule.recurs(2))
-            .catchAll(e => ZIO.logError(s"Webhook permanently failing, with last error being: ${e.msg}"))
-        }
+        val webhooks = allWebhooks.getOrElse(e.walletId, Nil)
+        val tasks = generateNotifyWebhookTasks(e, webhooks)
+          .map(
+            _.retry(Schedule.spaced(5.second) && Schedule.recurs(2))
+              .catchAll(e => ZIO.logError(s"Webhook permanently failing, with last error being: ${e.msg}"))
+          )
+        ZIO.collectAllDiscard(tasks)
       }
     } yield ()
   }
 
-  private[this] def notifyWebhook[A](event: Event[A], conf: EventNotificationConfig)(implicit
+  private[this] def generateNotifyWebhookTasks[A](
+      event: Event[A],
+      webhooks: Seq[EventNotificationConfig]
+  )(implicit encoder: JsonEncoder[A]): Seq[ZIO[Client, UnexpectedError, Unit]] = {
+    val globalWebhookTarget = config.url.map(_ -> globalWebhookBaseHeaders).toSeq
+    val walletWebhookTargets = webhooks
+      .map(i => i.url -> i.customHeaders)
+      .map { case (url, headers) =>
+        url -> headers.foldLeft(Headers.empty) { case (acc, (k, v)) => acc ++ Header(k, v) }
+      }
+    (walletWebhookTargets ++ globalWebhookTarget)
+      .map { case (url, headers) => notifyWebhook(event, url.toString, headers) }
+  }
+
+  private[this] def notifyWebhook[A](event: Event[A], url: String, headers: Headers)(implicit
       encoder: JsonEncoder[A]
   ): ZIO[Client, UnexpectedError, Unit] = {
-    val customHeaders = conf.customHeaders.foldLeft(Headers.empty) { case (acc, (k, v)) => acc ++ Header(k, v) }
     for {
-      _ <- ZIO.logDebug(s"Sending event: $event to HTTP webhook URL: ${conf.url}.")
+      _ <- ZIO.logDebug(s"Sending event: $event to HTTP webhook URL: $url.")
       response <- Client
         .request(
-          url = conf.url.toString,
+          url = url,
           method = Method.POST,
-          headers = baseHeaders ++ customHeaders,
+          headers = baseHeaders ++ headers,
           content = Body.fromString(event.toJson)
         )
         .timeoutFail(new RuntimeException("Client request timed out"))(5.seconds)

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
@@ -154,7 +154,6 @@ object AgentHttpServer {
     } yield ()
 }
 
-// TODO: add tests
 object AgentInitialization {
 
   private val defaultWalletId = WalletId.default

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
@@ -35,8 +35,6 @@ import io.iohk.atala.shared.models.WalletId
 import io.iohk.atala.system.controller.SystemServerEndpoints
 import zio.*
 
-import java.net.URL
-
 object PrismAgentApp {
 
   def run(didCommServicePort: Int) = for {
@@ -194,8 +192,7 @@ object AgentInitialization {
       _ <- walletService.createWallet(defaultWallet, seed)
       _ <- entityService.create(defaultEntity).mapError(e => Exception(e.message))
       _ <- apiKeyAuth.add(defaultEntity.id, config.authApiKey).mapError(e => Exception(e.message))
-      webhookUrl <- config.webhookUrl.fold(ZIO.none)(url => ZIO.attempt(URL(url)).asSome)
-      _ <- webhookUrl.fold(ZIO.unit) { url =>
+      _ <- config.webhookUrl.fold(ZIO.unit) { url =>
         val customHeaders = config.webhookApiKey.fold(Map.empty)(apiKey => Map("Authorization" -> s"Bearer $apiKey"))
         walletService
           .createWalletNotification(EventNotificationConfig(defaultWalletId, url, customHeaders))

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
@@ -154,9 +154,10 @@ object AgentHttpServer {
     } yield ()
 }
 
+// TODO: add tests
 object AgentInitialization {
 
-  private val defaultWalletId = WalletId.fromUUID(Entity.ZeroWalletId)
+  private val defaultWalletId = WalletId.default
   private val defaultWallet = Wallet("default", defaultWalletId)
   private val defaultEntity = Entity.Default
 

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
@@ -4,6 +4,10 @@ import io.iohk.atala.agent.notification.WebhookPublisher
 import io.iohk.atala.agent.server.config.AppConfig
 import io.iohk.atala.agent.server.http.{ZHttp4sBlazeServer, ZHttpEndpoints}
 import io.iohk.atala.agent.server.jobs.{BackgroundJobs, ConnectBackgroundJobs}
+import io.iohk.atala.agent.walletapi.model.Entity
+import io.iohk.atala.agent.walletapi.model.Wallet
+import io.iohk.atala.agent.walletapi.model.WalletSeed
+import io.iohk.atala.agent.walletapi.service.EntityService
 import io.iohk.atala.agent.walletapi.service.ManagedDIDService
 import io.iohk.atala.agent.walletapi.service.WalletManagementService
 import io.iohk.atala.castor.controller.{DIDRegistrarServerEndpoints, DIDServerEndpoints}
@@ -11,6 +15,8 @@ import io.iohk.atala.castor.core.service.DIDService
 import io.iohk.atala.connect.controller.ConnectionServerEndpoints
 import io.iohk.atala.connect.core.service.ConnectionService
 import io.iohk.atala.event.controller.EventServerEndpoints
+import io.iohk.atala.event.notification.EventNotificationConfig
+import io.iohk.atala.iam.authentication.apikey.ApiKeyAuthenticator
 import io.iohk.atala.iam.entity.http.EntityServerEndpoints
 import io.iohk.atala.iam.wallet.http.WalletManagementServerEndpoints
 import io.iohk.atala.issue.controller.IssueServerEndpoints
@@ -23,13 +29,18 @@ import io.iohk.atala.pollux.credentialschema.VerificationPolicyServerEndpoints
 import io.iohk.atala.pollux.vc.jwt.DidResolver as JwtDidResolver
 import io.iohk.atala.presentproof.controller.PresentProofServerEndpoints
 import io.iohk.atala.resolvers.DIDResolver
+import io.iohk.atala.shared.models.HexString
 import io.iohk.atala.shared.models.WalletAccessContext
+import io.iohk.atala.shared.models.WalletId
 import io.iohk.atala.system.controller.SystemServerEndpoints
 import zio.*
+
+import java.net.URL
 
 object PrismAgentApp {
 
   def run(didCommServicePort: Int) = for {
+    _ <- AgentInitialization.run
     _ <- issueCredentialDidCommExchangesJob.debug.fork
     _ <- presentProofExchangeJob.debug.fork
     _ <- connectDidCommExchangesJob.debug.fork
@@ -143,4 +154,53 @@ object AgentHttpServer {
       appConfig <- ZIO.service[AppConfig]
       _ <- server.start(allEndpoints, port = appConfig.agent.httpEndpoint.http.port).debug
     } yield ()
+}
+
+object AgentInitialization {
+
+  private val defaultWalletId = WalletId.fromUUID(Entity.ZeroWalletId)
+  private val defaultWallet = Wallet("default", defaultWalletId)
+  private val defaultEntity = Entity.Default
+
+  def run: RIO[AppConfig & WalletManagementService & EntityService & ApiKeyAuthenticator, Unit] =
+    initializeDefaultWallet
+
+  private val initializeDefaultWallet =
+    for {
+      _ <- ZIO.logInfo("Initializing default wallet.")
+      config <- ZIO.serviceWith[AppConfig](_.agent.defaultWallet)
+      walletService <- ZIO.service[WalletManagementService]
+      isDefaultWalletEnabled = config.enabled
+      isDefaultWalletExist <- walletService.getWallet(defaultWalletId).map(_.isDefined)
+      _ <- ZIO.logInfo(s"Default wallet not enabled.").when(!isDefaultWalletEnabled)
+      _ <- ZIO.logInfo(s"Default wallet already exist.").when(isDefaultWalletExist)
+      _ <- createDefaultWallet.when(isDefaultWalletEnabled && !isDefaultWalletExist)
+    } yield ()
+
+  private val createDefaultWallet =
+    for {
+      walletService <- ZIO.service[WalletManagementService]
+      entityService <- ZIO.service[EntityService]
+      apiKeyAuth <- ZIO.service[ApiKeyAuthenticator]
+      config <- ZIO.serviceWith[AppConfig](_.agent.defaultWallet)
+      seed <- config.seed.fold(ZIO.none) { seedHex =>
+        ZIO
+          .fromTry(HexString.fromString(seedHex))
+          .map(bytes => WalletSeed.fromByteArray(bytes.toByteArray).left.map(Exception(_)))
+          .absolve
+          .asSome
+      }
+      _ <- ZIO.logInfo(s"Default wallet seed is not provided. New seed will be generated.").when(seed.isEmpty)
+      _ <- walletService.createWallet(defaultWallet, seed)
+      _ <- entityService.create(defaultEntity).mapError(e => Exception(e.message))
+      _ <- apiKeyAuth.add(defaultEntity.id, config.authApiKey).mapError(e => Exception(e.message))
+      webhookUrl <- config.webhookUrl.fold(ZIO.none)(url => ZIO.attempt(URL(url)).asSome)
+      _ <- webhookUrl.fold(ZIO.unit) { url =>
+        val customHeaders = config.webhookApiKey.fold(Map.empty)(apiKey => Map("Authorization" -> s"Bearer $apiKey"))
+        walletService
+          .createWalletNotification(EventNotificationConfig(defaultWalletId, url, customHeaders))
+          .provide(ZLayer.succeed(WalletAccessContext(defaultWalletId)))
+      }
+    } yield ()
+
 }

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/config/AppConfig.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/config/AppConfig.scala
@@ -101,7 +101,19 @@ final case class VerificationConfig(options: Options) {
   }
 }
 
-final case class WebhookPublisherConfig(parallelism: Option[Int])
+final case class WebhookPublisherConfig(
+    url: Option[String],
+    apiKey: Option[String],
+    parallelism: Option[Int]
+)
+
+final case class DefaultWalletConfig(
+    enabled: Boolean,
+    seed: Option[String],
+    webhookUrl: Option[String],
+    webhookApiKey: Option[String],
+    authApiKey: String
+)
 
 final case class AgentConfig(
     httpEndpoint: HttpEndpointConfig,
@@ -110,7 +122,8 @@ final case class AgentConfig(
     database: DatabaseConfig,
     verification: VerificationConfig,
     secretStorage: SecretStorageConfig,
-    webhookPublisher: WebhookPublisherConfig
+    webhookPublisher: WebhookPublisherConfig,
+    defaultWallet: DefaultWalletConfig
 )
 
 final case class HttpEndpointConfig(http: HttpConfig)

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/config/AppConfig.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/config/AppConfig.scala
@@ -7,6 +7,7 @@ import io.iohk.atala.shared.db.DbConfig
 import zio.config.*
 import zio.config.magnolia.Descriptor
 
+import java.net.URL
 import java.time.Duration
 
 final case class AppConfig(
@@ -102,7 +103,7 @@ final case class VerificationConfig(options: Options) {
 }
 
 final case class WebhookPublisherConfig(
-    url: Option[String],
+    url: Option[URL],
     apiKey: Option[String],
     parallelism: Option[Int]
 )
@@ -110,7 +111,7 @@ final case class WebhookPublisherConfig(
 final case class DefaultWalletConfig(
     enabled: Boolean,
     seed: Option[String],
-    webhookUrl: Option[String],
+    webhookUrl: Option[URL],
     webhookApiKey: Option[String],
     authApiKey: String
 )

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/agent/server/AgentInitializationSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/agent/server/AgentInitializationSpec.scala
@@ -1,0 +1,80 @@
+package io.iohk.atala.agent.server
+
+import io.iohk.atala.agent.server.config.AppConfig
+import io.iohk.atala.agent.walletapi.crypto.ApolloSpecHelper
+import io.iohk.atala.agent.walletapi.service.EntityServiceImpl
+import io.iohk.atala.agent.walletapi.service.WalletManagementService
+import io.iohk.atala.agent.walletapi.service.WalletManagementServiceImpl
+import io.iohk.atala.agent.walletapi.sql.JdbcEntityRepository
+import io.iohk.atala.agent.walletapi.sql.JdbcWalletNonSecretStorage
+import io.iohk.atala.agent.walletapi.sql.JdbcWalletSecretStorage
+import io.iohk.atala.iam.authentication.apikey.ApiKeyAuthenticatorImpl
+import io.iohk.atala.iam.authentication.apikey.JdbcAuthenticationRepository
+import io.iohk.atala.shared.models.WalletId
+import io.iohk.atala.shared.test.containers.PostgresTestContainerSupport
+import io.iohk.atala.test.container.DBTestUtils
+import zio.*
+import zio.test.*
+import zio.test.Assertion.*
+import zio.test.ZIOSpecDefault
+
+object AgentInitializationSpec extends ZIOSpecDefault, PostgresTestContainerSupport, ApolloSpecHelper {
+
+  override def spec = {
+    val s = suite("AgentInitialization")(
+      initializeDefaultWalletSpec
+    ) @@ TestAspect.before(DBTestUtils.runMigrationAgentDB)
+
+    s.provide(
+      SystemModule.configLayer,
+      ZLayer.fromFunction((appConfig: AppConfig) => appConfig.agent.authentication.apiKey),
+      WalletManagementServiceImpl.layer,
+      ApiKeyAuthenticatorImpl.layer,
+      EntityServiceImpl.layer,
+      JdbcWalletNonSecretStorage.layer,
+      JdbcWalletSecretStorage.layer,
+      JdbcAuthenticationRepository.layer,
+      JdbcEntityRepository.layer,
+      contextAwareTransactorLayer,
+      systemTransactorLayer,
+      apolloLayer,
+      pgContainerLayer
+    )
+  }
+
+  private val initializeDefaultWalletSpec = suite("initializeDefaultWallet")(
+    test("do not create default wallet if disabled") {
+      for {
+        _ <- AgentInitialization.run.overrideConfig(enableDefaultWallet = false)
+        wallets <- ZIO.serviceWithZIO[WalletManagementService](_.listWallets()).map(_._1)
+      } yield assert(wallets)(isEmpty)
+    },
+    test("create default wallet if enabled") {
+      for {
+        _ <- AgentInitialization.run.overrideConfig(enableDefaultWallet = true)
+        wallets <- ZIO.serviceWithZIO[WalletManagementService](_.listWallets()).map(_._1)
+      } yield assert(wallets)(hasSize(equalTo(1))) &&
+        assert(wallets.headOption.map(_.id))(isSome(equalTo(WalletId.default)))
+    }
+  ) @@ TestAspect.tag("dev")
+
+  extension [R <: AppConfig, E, A](effect: ZIO[R, E, A]) {
+    def overrideConfig(enableDefaultWallet: Boolean = true): ZIO[R, E, A] = {
+      for {
+        appConfig <- ZIO.service[AppConfig]
+        agentConfig = appConfig.agent
+        defaultWalletConfig = agentConfig.defaultWallet
+        result <- effect.provideSomeLayer(
+          ZLayer.succeed(
+            appConfig.copy(
+              agent = agentConfig.copy(
+                defaultWallet = defaultWalletConfig.copy(enabled = enableDefaultWallet)
+              )
+            )
+          )
+        )
+      } yield result
+    }
+  }
+
+}

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/model/Entity.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/model/Entity.scala
@@ -12,7 +12,7 @@ case class Entity(id: UUID, name: String, walletId: UUID, createdAt: Instant, up
 
 object Entity {
 
-  val ZeroWalletId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+  val ZeroWalletId: UUID = WalletId.default.toUUID
 
   def apply(id: UUID, name: String, walletId: UUID): Entity =
     Entity(id, name, walletId, Instant.now(), Instant.now())

--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/model/Entity.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/model/Entity.scala
@@ -21,9 +21,15 @@ object Entity {
   def apply(name: String): Entity = Entity(UUID.randomUUID(), name, ZeroWalletId, Instant.now(), Instant.now())
 
   val Default =
-    Entity(UUID.fromString("00000000-0000-0000-0000-000000000000"), "default", ZeroWalletId, Instant.MIN, Instant.MIN)
+    Entity(
+      UUID.fromString("00000000-0000-0000-0000-000000000000"),
+      "default",
+      ZeroWalletId,
+      Instant.EPOCH,
+      Instant.EPOCH
+    )
   val Admin =
-    Entity(UUID.fromString("00000000-0000-0000-0000-000000000001"), "admin", ZeroWalletId, Instant.MIN, Instant.MIN)
+    Entity(UUID.fromString("00000000-0000-0000-0000-000000000001"), "admin", ZeroWalletId, Instant.EPOCH, Instant.EPOCH)
 
   extension (entity: Entity) {
     def walletAccessContext: WalletAccessContext = WalletAccessContext(WalletId.fromUUID(entity.walletId))


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes ATL-5698

Refine webhook and default wallet behavior
- `GLOBAL_WEBHOOK_` for configurations of global webhook (all wallets)
- `DEFAULT_WALLET_` for configurations of default wallet and automatically create one if not exist (seed, webhook, auth)

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
