### PR TITLE
fix: rename `api-key` header to `apikey`. Signed-off-by: Yurii Shynbu…

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,7 +111,7 @@ jobs:
         continue-on-error: true
         env:
           AGENT_AUTH_REQUIRED: "true"
-          AGENT_AUTH_HEADER: api-key
+          AGENT_AUTH_HEADER: apikey
           ACME_AUTH_KEY: default
           BOB_AUTH_KEY: default
           FABER_AUTH_KEY: default

--- a/infrastructure/local/run-e2e-tests-local.sh
+++ b/infrastructure/local/run-e2e-tests-local.sh
@@ -11,7 +11,7 @@ echo "--------------------------------------"
 ${SCRIPT_DIR}/run.sh -p 8080 -n multitenant -w
 
 export AGENT_AUTH_REQUIRED=true
-export AGENT_AUTH_HEADER=api-key
+export AGENT_AUTH_HEADER=apikey
 
 export ACME_AUTH_KEY=acme
 export ACME_AGENT_URL=http://localhost:8080/prism-agent
@@ -23,7 +23,7 @@ export FABER_AUTH_KEY=faber
 export FABER_AGENT_URL=http://localhost:8080/prism-agent
 
 curl --location 'http://localhost:8080/prism-agent/events/webhooks' \
-	--header "api-key: $ACME_AUTH_KEY" \
+	--header "apikey: $ACME_AUTH_KEY" \
 	--header 'Content-Type: application/json' \
 	--header 'Accept: application/json' \
 	--data '{
@@ -31,7 +31,7 @@ curl --location 'http://localhost:8080/prism-agent/events/webhooks' \
   }'
 
 curl --location 'http://localhost:8080/prism-agent/events/webhooks' \
-	--header "api-key: $BOB_AUTH_KEY" \
+	--header "apikey: $BOB_AUTH_KEY" \
 	--header 'Content-Type: application/json' \
 	--header 'Accept: application/json' \
 	--data '{
@@ -39,12 +39,13 @@ curl --location 'http://localhost:8080/prism-agent/events/webhooks' \
   }'
 
 curl --location 'http://localhost:8080/prism-agent/events/webhooks' \
-	--header "api-key: $FABER_AUTH_KEY" \
+	--header "apikey: $FABER_AUTH_KEY" \
 	--header 'Content-Type: application/json' \
 	--header 'Accept: application/json' \
 	--data '{
     "url": "http://host.docker.internal:9957"
   }'
+
 
 (
 	cd ${SCRIPT_DIR}/../../tests/e2e-tests/

--- a/prism-agent/service/server/src/main/resources/application.conf
+++ b/prism-agent/service/server/src/main/resources/application.conf
@@ -97,8 +97,8 @@ agent {
             salt = ${?API_KEY_SALT}
 
             # enabled is used to enable/disable the api key authentication
-            # if api-key authentication is disabled, the alternative authentication method is used
-            # if the alternative authentication method is not configured, api-key authentication is disabled the default user is used
+            # if apikey authentication is disabled, the alternative authentication method is used
+            # if the alternative authentication method is not configured, apikey authentication is disabled the default user is used
             enabled = true
             enabled = ${?API_KEY_ENABLED}
 

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/http/ZHttpEndpoints.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/http/ZHttpEndpoints.scala
@@ -48,8 +48,8 @@ object ZHttpEndpoints {
 
   private val apiKeySecuritySchema = SecurityScheme(
     `type` = "apiKey",
-    description = Some("API Key Authentication. The header `api-key` must be set with the API key."),
-    name = Some("api-key"),
+    description = Some("API Key Authentication. The header `apikey` must be set with the API key."),
+    name = Some("apikey"),
     in = Some("header"),
     scheme = None,
     bearerFormat = None,

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticator.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticator.scala
@@ -16,10 +16,10 @@ trait ApiKeyAuthenticator extends Authenticator {
           apiKey match {
             case Some(value) if value.nonEmpty => authenticate(value)
             case Some(value) =>
-              ZIO.logInfo(s"ApiKey API authentication is enabled, but `api-key` token is empty") *>
+              ZIO.logInfo(s"ApiKey API authentication is enabled, but `apikey` token is empty") *>
                 ZIO.fail(ApiKeyAuthenticationError.emptyApiKey)
             case None =>
-              ZIO.logInfo(s"ApiKey API authentication is enabled, but `api-key` token is not provided") *>
+              ZIO.logInfo(s"ApiKey API authentication is enabled, but `apikey` token is not provided") *>
                 ZIO.fail(InvalidCredentials("ApiKey key is not provided"))
           }
         case other =>

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyEndpointSecurityLogic.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyEndpointSecurityLogic.scala
@@ -8,7 +8,7 @@ import sttp.tapir.ztapir.*
 import zio.*
 
 object ApiKeyEndpointSecurityLogic {
-  val apiKeyHeader: EndpointIO.Header[ApiKeyCredentials] = header[Option[String]]("api-key")
+  val apiKeyHeader: EndpointIO.Header[ApiKeyCredentials] = header[Option[String]]("apikey")
     .mapTo[ApiKeyCredentials]
     .description("API key")
 

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/AuthenticationRepository.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/AuthenticationRepository.scala
@@ -10,7 +10,7 @@ import zio.interop.catz.*
 import java.util.UUID
 
 enum AuthenticationMethodType(val value: String) {
-  case ApiKey extends AuthenticationMethodType("api-key")
+  case ApiKey extends AuthenticationMethodType("apikey")
 }
 
 case class AuthenticationMethod(

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/package.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/authentication/apikey/package.scala
@@ -6,7 +6,7 @@ package object apikey {
   case class ApiKeyAuthenticationError(message: String) extends AuthenticationError
 
   object ApiKeyAuthenticationError {
-    val invalidApiKey = ApiKeyAuthenticationError("Invalid `api-key` header provided")
-    val emptyApiKey = ApiKeyAuthenticationError("Empty `api-key` header provided")
+    val invalidApiKey = ApiKeyAuthenticationError("Invalid `apikey` header provided")
+    val emptyApiKey = ApiKeyAuthenticationError("Empty `apikey` header provided")
   }
 }

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/entity/http/EntityEndpoints.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/iam/entity/http/EntityEndpoints.scala
@@ -201,24 +201,24 @@ object EntityEndpoints {
   ] = endpoint.post
     .securityIn(adminApiKeyHeader)
     .in(extractFromRequest[RequestContext](RequestContext.apply))
-    .in("iam" / "api-key-authentication")
+    .in("iam" / "apikey-authentication")
     .in(
       jsonBody[ApiKeyAuthenticationRequest]
         .description(
-          "JSON object required for the registering the entity and `api-key`"
+          "JSON object required for the registering the entity and `apikey`"
         )
     )
     .out(
       statusCode(StatusCode.Created)
         .description(
-          "The new `api-key` is successfully registered for the entity"
+          "The new `apikey` is successfully registered for the entity"
         )
     )
     .errorOut(basicFailureAndNotFoundAndForbidden)
     .name("addEntityApiKeyAuthentication")
-    .summary("Register the `api-key` for the entity")
+    .summary("Register the `apikey` for the entity")
     .description(
-      "Register the `api-key` for the entity."
+      "Register the `apikey` for the entity."
     )
     .tag("Identity and Access Management")
 
@@ -231,24 +231,24 @@ object EntityEndpoints {
   ] = endpoint.delete
     .securityIn(adminApiKeyHeader)
     .in(extractFromRequest[RequestContext](RequestContext.apply))
-    .in("iam" / "api-key-authentication")
+    .in("iam" / "apikey-authentication")
     .in(
       jsonBody[ApiKeyAuthenticationRequest]
         .description(
-          "JSON object required for the unregistering the entity and `api-key`"
+          "JSON object required for the unregistering the entity and `apikey`"
         )
     )
     .out(
       statusCode(StatusCode.Ok)
         .description(
-          "The new `api-key` is successfully unregistered for the entity"
+          "The new `apikey` is successfully unregistered for the entity"
         )
     )
     .errorOut(basicFailureAndNotFoundAndForbidden)
     .name("deleteEntityApiKeyAuthentication")
-    .summary("Unregister the `api-key` for the entity")
+    .summary("Unregister the `apikey` for the entity")
     .description(
-      "Unregister the `api-key` for the entity."
+      "Unregister the `apikey` for the entity."
     )
     .tag("Identity and Access Management")
 }

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/agent/server/AgentInitializationSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/agent/server/AgentInitializationSpec.scala
@@ -92,7 +92,7 @@ object AgentInitializationSpec extends ZIOSpecDefault, PostgresTestContainerSupp
         assert(webhooks.head.customHeaders)(isEmpty) &&
         assert(webhooks)(hasSize(equalTo(1)))
     },
-    test("create wallet with provided webhook and api-key") {
+    test("create wallet with provided webhook and apikey") {
       val url = "http://example.com"
       val apiKey = "secret"
       for {

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticatorSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/iam/authentication/apikey/ApiKeyAuthenticatorSpec.scala
@@ -137,7 +137,7 @@ object ApiKeyAuthenticatorSpec extends ZIOSpecDefault, PostgresTestContainerSupp
           )
         } yield assert(authenticatedEntity)(equalTo(entity))
       ),
-      test("unregistered entity is authenticated (assuming that the api-key is valid)")(
+      test("unregistered entity is authenticated (assuming that the apikey is valid)")(
         for {
           authenticatedEntity2 <- ApiKeyAuthenticator.authenticate(ApiKeyCredentials(Option("registered-key#2")))
           authenticatedEntity3 <- ApiKeyAuthenticator.authenticate(ApiKeyCredentials(Option("registered-key#3")))


### PR DESCRIPTION
…iev yurii.shynbuiev@iohk.io
Rename  the header for api key authentication from`api-key` to `apikey` 

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
