### PR TITLE
fix(prism-agent): validate application config during startup

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/castor/controller/DIDRegistrarEndpoints.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/castor/controller/DIDRegistrarEndpoints.scala
@@ -54,7 +54,10 @@ object DIDRegistrarEndpoints {
     Any
   ] = baseEndpoint.post
     .in(jsonBody[CreateManagedDidRequest])
-    .errorOut(EndpointOutputs.basicFailuresWith(FailureVariant.unprocessableEntity, FailureVariant.notFound))
+    .errorOut(
+      EndpointOutputs
+        .basicFailuresWith(FailureVariant.unprocessableEntity, FailureVariant.notFound, FailureVariant.forbidden)
+    )
     .out(statusCode(StatusCode.Created).description("Created unpublished DID."))
     .out(jsonBody[CreateManagedDIDResponse])
     .summary("Create unpublished DID and store it in Prism Agent's wallet")


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

We start to have environment variables that shouldn't work in some permutation. It is slightly confusing to user when those are conflicting each other. This PR add some sanity check for the config and stops the Agent from starting with an error message.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [x] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
